### PR TITLE
Add functions to access Zend Engine garbage collection metrics.

### DIFF
--- a/php_xdebug.h
+++ b/php_xdebug.h
@@ -121,6 +121,8 @@ PHP_FUNCTION(xdebug_clear_aggr_profiling_data);
 PHP_FUNCTION(xdebug_start_gcstats);
 PHP_FUNCTION(xdebug_stop_gcstats);
 PHP_FUNCTION(xdebug_get_gcstats_filename);
+PHP_FUNCTION(xdebug_get_gc_run_count);
+PHP_FUNCTION(xdebug_get_gc_total_collected_roots);
 
 /* misc functions */
 PHP_FUNCTION(xdebug_dump_superglobals);

--- a/tests/xdebug_gc_stats7.phpt
+++ b/tests/xdebug_gc_stats7.phpt
@@ -1,0 +1,22 @@
+--TEST--
+GC Stats: userland statistic functions
+--INI--
+zend.enable_gc=1
+--FILE--
+<?php
+
+for ($i = 0; $i < 100; $i++) {
+	$a = new stdClass();
+	$b = new stdClass();
+	$b->a = $a;
+	$a->b = $b;
+	unset($a, $b);
+}
+gc_collect_cycles();
+
+printf("runs: %d\n", xdebug_get_gc_run_count());
+printf("collected: %d\n", xdebug_get_gc_total_collected_roots());
+?>
+--EXPECTF--
+runs: 1
+collected: 200

--- a/xdebug.c
+++ b/xdebug.c
@@ -205,6 +205,8 @@ zend_function_entry xdebug_functions[] = {
 	PHP_FE(xdebug_start_gcstats,         xdebug_start_gcstats_args)
 	PHP_FE(xdebug_stop_gcstats,          xdebug_stop_gcstats_args)
 	PHP_FE(xdebug_get_gcstats_filename,  xdebug_void_args)
+	PHP_FE(xdebug_get_gc_run_count,      xdebug_void_args)
+	PHP_FE(xdebug_get_gc_total_collected_roots, xdebug_void_args)
 
 	PHP_FE(xdebug_memory_usage,          xdebug_void_args)
 	PHP_FE(xdebug_peak_memory_usage,     xdebug_void_args)

--- a/xdebug_gc_stats.c
+++ b/xdebug_gc_stats.c
@@ -243,3 +243,17 @@ PHP_FUNCTION(xdebug_stop_gcstats)
 		php_error(E_NOTICE, "Function trace was not started");
 	}
 }
+
+/* {{{ proto void xdebug_get_gc_run_count()
+   Return number of times garbage collection was triggered. */
+PHP_FUNCTION(xdebug_get_gc_run_count)
+{
+    RETURN_LONG(GC_G(gc_runs));
+}
+
+/* {{{ proto void xdebug_get_gc_total_collected_roots()
+   Return number of times garbage collection was triggered. */
+PHP_FUNCTION(xdebug_get_gc_total_collected_roots)
+{
+    RETURN_LONG(GC_G(collected));
+}


### PR DESCRIPTION
Number of garbage collection runs and total of collected roots metrics
exist in Zend Engine, but are not exposed to userland. These are helpful
to integrate in development to find out scripts that trigger GC.